### PR TITLE
Fix Worldmap Corruption issues

### DIFF
--- a/SourceCode/autoload/Global.gd
+++ b/SourceCode/autoload/Global.gd
@@ -210,18 +210,15 @@ func level_completed():
 			emit_signal("level_cleared")
 
 func save_node_to_directory(node : Node, dir : String):
-	while true:
-		for child in node.get_children():
-			child.owner = node
-			for baby in child.get_children():
-				baby.owner = node
-		var packed_scene = PackedScene.new()
-		packed_scene.pack(node)
-		var err = ResourceSaver.save(dir, packed_scene)
-		if err == OK:
-			break
-		else:
-			printerr("Error Code when saving: %s" % err)
+	for child in node.get_children():
+		child.owner = node
+		for baby in child.get_children():
+			baby.owner = node
+	var packed_scene = PackedScene.new()
+	packed_scene.pack(node)
+	var err = ResourceSaver.save(dir, packed_scene)
+	if err != OK:
+		printerr("Error Code when saving: %s" % err)
 
 # Gets ALL children in a node, including children of children.
 func get_all_children(node, array := []):

--- a/SourceCode/autoload/Global.gd
+++ b/SourceCode/autoload/Global.gd
@@ -57,7 +57,6 @@ signal level_cleared
 signal object_clicked
 
 func _ready():
-	print_debug(OS.get_user_data_dir())
 	self.gravity = 1
 	var root = get_tree().get_root()
 	current_scene = root.get_child(root.get_child_count() - 1)

--- a/SourceCode/autoload/Global.gd
+++ b/SourceCode/autoload/Global.gd
@@ -57,6 +57,7 @@ signal level_cleared
 signal object_clicked
 
 func _ready():
+	print_debug(OS.get_user_data_dir())
 	self.gravity = 1
 	var root = get_tree().get_root()
 	current_scene = root.get_child(root.get_child_count() - 1)
@@ -210,13 +211,18 @@ func level_completed():
 			emit_signal("level_cleared")
 
 func save_node_to_directory(node : Node, dir : String):
-	for child in node.get_children():
-		child.owner = node
-		for baby in child.get_children():
-			baby.owner = node
-	var packed_scene = PackedScene.new()
-	packed_scene.pack(node)
-	ResourceSaver.save(dir, packed_scene)
+	while true:
+		for child in node.get_children():
+			child.owner = node
+			for baby in child.get_children():
+				baby.owner = node
+		var packed_scene = PackedScene.new()
+		packed_scene.pack(node)
+		var err = ResourceSaver.save(dir, packed_scene)
+		if err == OK:
+			break
+		else:
+			printerr("Error Code when saving: %s" % err)
 
 # Gets ALL children in a node, including children of children.
 func get_all_children(node, array := []):

--- a/SourceCode/scenes/leveleditor/menus/PauseScreen.gd
+++ b/SourceCode/scenes/leveleditor/menus/PauseScreen.gd
@@ -55,7 +55,13 @@ func _on_Options_mouse_entered():
 	button_options.grab_focus()
 
 func _on_Quit_pressed():
-	emit_signal("save_and_quit")
+	var par = get_parent()
+	if par.edit_mode:
+		emit_signal("save_and_quit")
+	else:
+		par._deferred_enter_edit_mode()
+		menu.hide()
+		par.save_level()
 
 func _on_Quit_mouse_entered():
 	button_quit.grab_focus()


### PR DESCRIPTION
I have explained this in the developers chat, but to reiterate:
When pressing save and quit whilst playing the worldmap, it would attempt to save the worldmap in an invalid state.
This caused a crash *and* the worldmap to be corrupted.
This PR fixes both via adjusting the pause menu code for the level editor.

Additional change: Global.save_node_to_directory now will printerr if saving fails.